### PR TITLE
Make auto threshold commutative

### DIFF
--- a/src/main/java/Coloc_2.java
+++ b/src/main/java/Coloc_2.java
@@ -685,7 +685,8 @@ public class Coloc_2<T extends RealType< T > & NativeType< T >> implements PlugI
 		// prepare output image
 		ImgFactory<T> maskFactory = new ArrayImgFactory<T>();
 		//Img<T> maskImage = maskFactory.create( size, name );
-		RandomAccessibleInterval<T> maskImage = maskFactory.create( size, image.randomAccess().get() );
+		RandomAccessibleInterval<T> maskImage = maskFactory.create( size,
+				image.randomAccess().get().createVariable() );
 		RandomAccess<T> maskCursor = maskImage.randomAccess();
 		// go through the visible data and copy it to the output
 		while (cursor.hasNext()) {

--- a/src/main/java/algorithms/AutoThresholdRegression.java
+++ b/src/main/java/algorithms/AutoThresholdRegression.java
@@ -60,12 +60,13 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 		double combinedSum = 0.0;
 		int N = 0, NZero = 0;
 
+		// reference image data type
+		final T type = cursor.getFirst();
+
 		while (cursor.hasNext()) {
 			cursor.fwd();
-			T type1 = cursor.getFirst();
-			double ch1 = type1.getRealDouble();
-			T type2 = cursor.getSecond();
-			double ch2 = type2.getRealDouble();
+			double ch1 = cursor.getFirst().getRealDouble();
+			double ch2 = cursor.getSecond().getRealDouble();
 
 			combinedSum = ch1 + ch2;
 
@@ -122,15 +123,15 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 		double ch2ThreshMax = container.getMaxCh2();
 
 		// define some image type specific threshold variables
-		T thresholdCh1 = img1.randomAccess().get();
-		T thresholdCh2 = img2.randomAccess().get();
+		T thresholdCh1 = type.createVariable();
+		T thresholdCh2 = type.createVariable();
 		// reset the previously created cursor
 		cursor.reset();
 
 		/* Get min and max value of image data type. Since type of image
 		 * one and two are the same, we dont't need to distinguish them.
 		 */
-		T dummyT = img1.randomAccess().get();
+		T dummyT = type.createVariable();
 		final double minVal = dummyT.getMinValue();
 		final double maxVal = dummyT.getMaxValue();
 
@@ -189,16 +190,16 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 		 * min value for now. For the max threshold we do a clipping
 		 * to make it fit into the image type.
 		 */
-		ch1MinThreshold = img1.randomAccess().get();
+		ch1MinThreshold = type.createVariable();
 		ch1MinThreshold.setReal(minVal);
 
-		ch1MaxThreshold = img1.randomAccess().get();
+		ch1MaxThreshold = type.createVariable();
 		ch1MaxThreshold.setReal(clamp(ch1ThreshMax, minVal, maxVal));
 
-		ch2MinThreshold = img2.randomAccess().get();
+		ch2MinThreshold = type.createVariable();
 		ch2MinThreshold.setReal(minVal);
 
-		ch2MaxThreshold = img2.randomAccess().get();
+		ch2MaxThreshold = type.createVariable();
 		ch2MaxThreshold.setReal(clamp(ch2ThreshMax, minVal, maxVal));
 
 		autoThresholdSlope = m;

--- a/src/main/java/algorithms/AutoThresholdRegression.java
+++ b/src/main/java/algorithms/AutoThresholdRegression.java
@@ -169,7 +169,7 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 			if (thrDiff < 1.0)
 				thresholdFound = true;
 
-			// update working thresholds
+			// update working thresholds for next iteration
 			threshold2 = threshold1;
 			if (badResult || currentPersonsR < 0) {
 				// we went too far, increase by the absolute half

--- a/src/main/java/algorithms/ChannelMapper.java
+++ b/src/main/java/algorithms/ChannelMapper.java
@@ -1,0 +1,12 @@
+package algorithms;
+
+/**
+ * A channel mapper should map an input value to either channel one or
+ * channel two.
+ * 
+ * @author Tom Kazimiers
+ */
+public interface ChannelMapper {
+	double getCh1Threshold(double t);
+	double getCh2Threshold(double t);
+}

--- a/src/main/java/algorithms/CostesSignificanceTest.java
+++ b/src/main/java/algorithms/CostesSignificanceTest.java
@@ -133,7 +133,7 @@ public class CostesSignificanceTest<T extends RealType< T > & NativeType<T>> ext
 		}
 		
 		// we will need a zero variable
-		final T zero = img1.randomAccess().get();
+		final T zero = img1.randomAccess().get().createVariable();
 		zero.setZero();
 
 		/* Create a new image to contain the shuffled data and with
@@ -143,7 +143,7 @@ public class CostesSignificanceTest<T extends RealType< T > & NativeType<T>> ext
 		img1.dimensions(dims);
 		ImgFactory<T> factory = new ArrayImgFactory<T>();
 		Img<T> shuffledImage = factory.create(
-				dims, img1.randomAccess().get() );
+				dims, img1.randomAccess().get().createVariable() );
 		RandomAccessible< T> infiniteShuffledImage =
 				Views.extendValue(shuffledImage, zero );
 

--- a/src/test/java/tests/AutoThresholdRegressionTest.java
+++ b/src/test/java/tests/AutoThresholdRegressionTest.java
@@ -1,11 +1,17 @@
 package tests;
 
 import static org.junit.Assert.assertEquals;
+import gadgets.DataContainer;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
 
 import org.junit.Test;
 
+import com.sun.jdi.FloatType;
+
 import algorithms.AutoThresholdRegression;
 import algorithms.MissingPreconditionException;
+import algorithms.PearsonsCorrelation;
 
 
 public class AutoThresholdRegressionTest extends ColocalisationTest {
@@ -16,5 +22,46 @@ public class AutoThresholdRegressionTest extends ColocalisationTest {
 		assertEquals(1, AutoThresholdRegression.clamp(-2, 1, 4), 0.00001);
 		assertEquals(1, AutoThresholdRegression.clamp(5, 1, 1), 0.00001);
 		assertEquals(2, AutoThresholdRegression.clamp(2, -1, 3), 0.00001);
+	}
+
+	/**
+	 * This test makes sure the test images A and B lead to the same thresholds,
+	 * regardless whether they are added in the order A, B or B, A to the data
+	 * container.
+	 *
+	 * @throws MissingPreconditionException
+	 */
+	@Test
+	public void cummutativityTest() throws MissingPreconditionException {
+		PearsonsCorrelation<UnsignedByteType> pc1 =
+				new PearsonsCorrelation<UnsignedByteType>(
+						PearsonsCorrelation.Implementation.Fast);
+		PearsonsCorrelation<UnsignedByteType> pc2 =
+				new PearsonsCorrelation<UnsignedByteType>(
+						PearsonsCorrelation.Implementation.Fast);
+
+		AutoThresholdRegression<UnsignedByteType> atr1 =
+				new AutoThresholdRegression<UnsignedByteType>(pc1);
+		AutoThresholdRegression<UnsignedByteType> atr2 =
+				new AutoThresholdRegression<UnsignedByteType>(pc2);
+
+		RandomAccessibleInterval<UnsignedByteType> img1 = syntheticNegativeCorrelationImageCh1;
+		RandomAccessibleInterval<UnsignedByteType> img2 = syntheticNegativeCorrelationImageCh2;
+
+		DataContainer<UnsignedByteType> container1 =
+				new DataContainer<UnsignedByteType>(img1, img2, 1, 1,
+						"Channel 1", "Channel 2");
+
+		DataContainer<UnsignedByteType> container2 =
+				new DataContainer<UnsignedByteType>(img2, img1, 1, 1,
+						"Channel 2", "Channel 1");
+
+		atr1.execute(container1);
+		atr2.execute(container2);
+
+		assertEquals(atr1.getCh1MinThreshold(), atr2.getCh2MinThreshold());
+		assertEquals(atr1.getCh1MaxThreshold(), atr2.getCh2MaxThreshold());
+		assertEquals(atr1.getCh2MinThreshold(), atr2.getCh1MinThreshold());
+		assertEquals(atr1.getCh2MaxThreshold(), atr2.getCh1MaxThreshold());
 	}
 }

--- a/src/test/java/tests/CommutativityTest.java
+++ b/src/test/java/tests/CommutativityTest.java
@@ -1,0 +1,82 @@
+package tests;
+
+import static org.junit.Assert.assertEquals;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.TwinCursor;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.RealType;
+import net.imglib2.view.Views;
+
+import org.junit.Test;
+
+import algorithms.LiICQ;
+import algorithms.MandersColocalization;
+import algorithms.MandersColocalization.MandersResults;
+import algorithms.MissingPreconditionException;
+import algorithms.PearsonsCorrelation;
+import algorithms.SpearmanRankCorrelation;
+
+public class CommutativityTest extends ColocalisationTest {
+
+	/**
+	 * This test makes sure the test images A and B lead to the same results,
+	 * regardless whether they are added in the order A, B or B, A to the data
+	 * container.
+	 *
+	 * @throws MissingPreconditionException
+	 */
+	@Test
+	public void cummutativityTest() throws MissingPreconditionException {
+		assertCommutativity(zeroCorrelationImageCh1, zeroCorrelationImageCh2,
+				zeroCorrelationAlwaysTrueMask, zeroCorrelationImageCh1Mean,
+				zeroCorrelationImageCh2Mean);
+		assertCommutativity(positiveCorrelationImageCh1, positiveCorrelationImageCh1,
+				positiveCorrelationAlwaysTrueMask, positiveCorrelationImageCh1Mean,
+				positiveCorrelationImageCh2Mean);
+		assertCommutativity(syntheticNegativeCorrelationImageCh1,
+				syntheticNegativeCorrelationImageCh2,
+				syntheticNegativeCorrelationAlwaysTrueMask,
+				syntheticNegativeCorrelationImageCh1Mean,
+				syntheticNegativeCorrelationImageCh2Mean);
+	}
+	
+	protected static <T extends RealType< T > > void assertCommutativity(
+			RandomAccessibleInterval<T> ch1, RandomAccessibleInterval<T> ch2,
+			RandomAccessibleInterval<BitType> mask, double mean1, double mean2)
+			throws MissingPreconditionException
+	{
+		// create a twin value range cursor that iterates over all pixels of the input data
+		TwinCursor<T> cursor1 = new TwinCursor<T>(ch1.randomAccess(),
+				ch2.randomAccess(), Views.iterable(mask).localizingCursor());
+		TwinCursor<T> cursor2 = new TwinCursor<T>(ch1.randomAccess(),
+				ch2.randomAccess(), Views.iterable(mask).localizingCursor());
+		
+		// get the Pearson's values
+		double pearsonsR1 = PearsonsCorrelation.fastPearsons(cursor1);
+		double pearsonsR2 = PearsonsCorrelation.fastPearsons(cursor2);
+		// check Pearsons R is the same
+		assertEquals(pearsonsR1, pearsonsR2, 0.0001);
+		
+		// get Li's ICQ values
+		double icq1 = LiICQ.calculateLisICQ(cursor1, mean1, mean2);
+		double icq2 = LiICQ.calculateLisICQ(cursor2, mean2, mean1);
+		// check Li's ICQ is the same
+		assertEquals(icq1, icq2, 0.0001);
+		
+		// get Manders values
+		MandersColocalization<T> mc = new MandersColocalization<T>();
+		MandersResults manders1 = mc.calculateMandersCorrelation(cursor1,
+				ch1.randomAccess().get().createVariable());
+		MandersResults manders2 = mc.calculateMandersCorrelation(cursor2,
+				ch2.randomAccess().get().createVariable());
+		// check Manders m1 and m2 values are the same
+		assertEquals(manders1.m1, manders2.m2, 0.0001);
+		assertEquals(manders1.m2, manders2.m1, 0.0001);
+		
+		// calculate Spearman's Rank rho values
+		double rho1 = SpearmanRankCorrelation.calculateSpearmanRank(cursor1);
+		double rho2 = SpearmanRankCorrelation.calculateSpearmanRank(cursor2);
+		// make sure both ranks are the same
+		assertEquals(rho1, rho2, 0.0001);
+	}
+}

--- a/src/test/java/tests/MandersColocalizationTest.java
+++ b/src/test/java/tests/MandersColocalizationTest.java
@@ -27,7 +27,7 @@ public class MandersColocalizationTest extends ColocalisationTest {
 				Views.iterable(mandersAlwaysTrueMask).localizingCursor());
 
 		r = mc.calculateMandersCorrelation(cursor,
-				mandersA.randomAccess().get());
+				mandersA.randomAccess().get().createVariable());
 
 		assertEquals(1.0d, r.m1, 0.0001);
 		assertEquals(1.0d, r.m2, 0.0001);

--- a/src/test/java/tests/TestImageAccessor.java
+++ b/src/test/java/tests/TestImageAccessor.java
@@ -252,7 +252,7 @@ public class TestImageAccessor {
 		final long[] dim = new long[ img.numDimensions() ];
 		img.dimensions(dim);
 		RandomAccessibleInterval<T> output = outputFactory.create( dim,
-				img.randomAccess().get() );
+				img.randomAccess().get().createVariable() );
 
 		final long[] pos = new long[ img.numDimensions() ];
 		Arrays.fill(pos, 0);
@@ -280,7 +280,7 @@ public class TestImageAccessor {
 		image.dimensions(dim);
 		ArrayImgFactory<T> imgFactory = new ArrayImgFactory<T>();
 		RandomAccessibleInterval<T> invImg = imgFactory.create(
-				dim, image.randomAccess().get() ); // "Inverted " + image.getName());
+				dim, image.randomAccess().get().createVariable() ); // "Inverted " + image.getName());
 		RandomAccess<T> invCursor = invImg.randomAccess();
 
 		while (imgCursor.hasNext()) {
@@ -317,7 +317,7 @@ public class TestImageAccessor {
 		image.dimensions(dim);
 		ArrayImgFactory<T> imgFactory = new ArrayImgFactory<T>();
 		RandomAccessibleInterval<T> binImg = imgFactory.create( dim,
-				image.randomAccess().get() ); // "Binary image of " + image.getName());
+				image.randomAccess().get().createVariable() ); // "Binary image of " + image.getName());
 		RandomAccess<T> invCursor = binImg.randomAccess();
 
 		while (imgCursor.hasNext()) {


### PR DESCRIPTION
This pull request includes two bug fixes. The first one makes sure new generic based variables are created correctly with `createVariable()` in all places that expect a completely new instance. The second fix makes the auto threshold regression commutative. This means it doesn't matter anymore if it operates on two images regardless if they are passed in as channel one and B or B and A. Birgit Möller noted some time ago on the ImageJ mailing list that Coloc 2 given different results if input channel order is reversed. This problem should be fixed with this pull request.