### PR TITLE
Add and default to regression pattern used by Costes

### DIFF
--- a/src/main/java/Coloc_2.java
+++ b/src/main/java/Coloc_2.java
@@ -46,7 +46,6 @@ import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 import results.PDFWriter;
 import results.ResultHandler;

--- a/src/main/java/algorithms/AutoThresholdRegression.java
+++ b/src/main/java/algorithms/AutoThresholdRegression.java
@@ -140,7 +140,7 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 			// Select a stepper
 			if (implementation == Implementation.Bisection) {
 				// Start at the midpoint of channel one
-				stepper = new Bisectiontepper(
+				stepper = new BisectionStepper(
 					Math.abs(container.getMaxCh1() + container.getMinCh1()) * 0.5,
 					container.getMaxCh1());
 			} else {
@@ -165,7 +165,7 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 			// Select a stepper
 			if (implementation == Implementation.Bisection) {
 				// Start at the midpoint of channel two
-				stepper = new Bisectiontepper(
+				stepper = new BisectionStepper(
 					Math.abs(container.getMaxCh2() + container.getMinCh2()) * 0.5,
 					container.getMaxCh2());
 			} else {

--- a/src/main/java/algorithms/AutoThresholdRegression.java
+++ b/src/main/java/algorithms/AutoThresholdRegression.java
@@ -6,7 +6,6 @@ import net.imglib2.RandomAccessibleInterval;
 import net.imglib2.TwinCursor;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 import results.ResultHandler;
 
@@ -15,6 +14,9 @@ import results.ResultHandler;
  * used for Person colocalisation calculation.
  */
 public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<T> {
+	// Identifiers for choosing which implementation to use
+	public enum Implementation {Costes, Bisection};
+	Implementation implementation = Implementation.Bisection;
 	/* the threshold for y-intercept to y-max to
 	 *  raise a warning about it being to high.
 	 */
@@ -33,8 +35,13 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 	PearsonsCorrelation<T> pearsonsCorrellation;
 
 	public AutoThresholdRegression(PearsonsCorrelation<T> pc) {
+		this(pc, Implementation.Costes);
+	}
+
+	public AutoThresholdRegression(PearsonsCorrelation<T> pc, Implementation impl) {
 		super("auto threshold regression");
 		pearsonsCorrellation = pc;
+		implementation = impl;
 	}
 
 	@Override
@@ -107,15 +114,8 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 		final double m = num/denom;
 		final double b = ch2Mean - m*ch1Mean ;
 
-		// initialize some variables relevant for regression
-		// indicates whether the threshold has been found or not
-		boolean thresholdFound = false;
-		// the maximum number of iterations to look for the threshold
-		final int maxIterations = 100;
-		// the current iteration
-		int iteration = 0;
-		// current and last working threshold
-		double threshold1, threshold2;
+		// A stepper that walks thresholds
+		Stepper stepper;
 		// to map working thresholds to channels
 		ChannelMapper mapper;
 
@@ -123,11 +123,6 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 		// leans more towards the abscissa (which represents channel one) for
 		// positive and negative correlation.
 		if (m > -1 && m < 1.0) {
-			// Start at the midpoint of channel one
-			threshold1 = Math.abs(container.getMaxCh1() +
-					container.getMinCh1()) * 0.5;
-			threshold2 = container.getMaxCh1();
-
 			// Map working threshold to channel one (because channel one has a
 			// larger maximum value.
 			mapper = new ChannelMapper() {
@@ -142,12 +137,17 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 					return (t * m) + b;
 				}
 			};
-		} else {
-			// Start at the midpoint of channel two
-			threshold1 = Math.abs(container.getMaxCh2() +
-					container.getMinCh2()) * 0.5;
-			threshold2 = container.getMaxCh2();
+			// Select a stepper
+			if (implementation == Implementation.Bisection) {
+				// Start at the midpoint of channel one
+				stepper = new Bisectiontepper(
+					Math.abs(container.getMaxCh1() + container.getMinCh1()) * 0.5,
+					container.getMaxCh1());
+			} else {
+				stepper = new SimpleStepper(container.getMaxCh1());
+			}
 
+		} else {
 			// Map working threshold to channel two (because channel two has a
 			// larger maximum value.
 			mapper = new ChannelMapper() {
@@ -162,6 +162,15 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 					return t;
 				}
 			};
+			// Select a stepper
+			if (implementation == Implementation.Bisection) {
+				// Start at the midpoint of channel two
+				stepper = new Bisectiontepper(
+					Math.abs(container.getMaxCh2() + container.getMinCh2()) * 0.5,
+					container.getMaxCh2());
+			} else {
+				stepper = new SimpleStepper(container.getMaxCh2());
+			}
 		}
 
 		// Min threshold not yet implemented
@@ -182,53 +191,31 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 		final double maxVal = dummyT.getMaxValue();
 
 		// do regression
-		while (!thresholdFound && iteration<maxIterations) {
+		while (!stepper.isFinished()) {
 			// round ch1 threshold and compute ch2 threshold
-			ch1ThreshMax = Math.round(mapper.getCh1Threshold(threshold1));
-			ch2ThreshMax = Math.round(mapper.getCh2Threshold(threshold1));
+			ch1ThreshMax = Math.round(mapper.getCh1Threshold(stepper.getValue()));
+			ch2ThreshMax = Math.round(mapper.getCh2Threshold(stepper.getValue()));
 			/* Make sure we don't get overflow the image type specific threshold variables
 			 * if the image data type doesn't support this value.
 			 */
 			thresholdCh1.setReal(clamp(ch1ThreshMax, minVal, maxVal));
 			thresholdCh2.setReal(clamp(ch2ThreshMax, minVal, maxVal));
 
-			// Person's R value
-			double currentPersonsR = Double.MAX_VALUE;
-			// indicates if we have actually found a real number
-			boolean badResult = false;
 			try {
 				// do persons calculation within the limits
-				currentPersonsR = pearsonsCorrellation.calculatePearsons(cursor,
-						ch1Mean, ch2Mean, thresholdCh1, thresholdCh2, ThresholdMode.Below);
+				final double currentPersonsR =
+						pearsonsCorrellation.calculatePearsons(cursor,
+						ch1Mean, ch2Mean, thresholdCh1, thresholdCh2,
+						ThresholdMode.Below);
+				stepper.update(currentPersonsR);
 			} catch (MissingPreconditionException e) {
 				/* the exception that could occur is due to numerical
-				 * problems within the pearsons calculation.
-				 */
-				badResult = true;
-			}
-
-			/* If the difference between both thresholds is < 1, we consider
-			 * that as reasonable close to abort the regression.
-			 */
-			final double thrDiff = Math.abs(threshold1 - threshold2);
-			if (thrDiff < 1.0)
-				thresholdFound = true;
-
-			// update working thresholds for next iteration
-			threshold2 = threshold1;
-			if (badResult || currentPersonsR < 0) {
-				// we went too far, increase by the absolute half
-				threshold1 = threshold1 + thrDiff * 0.5;
-			} else if (currentPersonsR > 0) {
-				// as long as r > 0 we go half the way down
-				threshold1 = threshold1 - thrDiff * 0.5;
+				 * problems within the Pearsons calculation. */
+				stepper.update(Double.NaN);
 			}
 
 			// reset the cursor to reuse it
 			cursor.reset();
-
-			// increment iteration counter
-			iteration++;
 		}
 
 		/* Store the new results. The lower thresholds are the types
@@ -269,8 +256,9 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 
 		// add warnings if values are below lowest pixel value of images
 		if ( ch1ThreshMax < container.getMinCh1() || ch2ThreshMax < container.getMinCh2() ) {
-			addWarning("thresholds too low",
-				"The auto threshold method could not find a positive threshold.");
+			String msg ="The auto threshold method could not find a positive threshold.";
+			msg += implementation == Implementation.Costes ? "" : " Maybe you should try classic thresholding.";
+			addWarning("thresholds too low", msg);
 		}
 	}
 
@@ -291,6 +279,7 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 		handler.handleValue( "b to y-max ratio", bToYMaxRatio, 2 );
 		handler.handleValue( "Ch1 Max Threshold", ch1MaxThreshold.getRealDouble(), 2);
 		handler.handleValue( "Ch2 Max Threshold", ch2MaxThreshold.getRealDouble(), 2);
+		handler.handleValue( "Threshold regression", implementation.toString());
 	}
 
 	public double getBToYMaxRatio() {

--- a/src/main/java/algorithms/BisectionStepper.java
+++ b/src/main/java/algorithms/BisectionStepper.java
@@ -9,7 +9,7 @@ package algorithms;
  * @author Tom Kazimiers
  *
  */
-public class Bisectiontepper extends Stepper {
+public class BisectionStepper extends Stepper {
 	protected double threshold1;
 	protected double threshold2;
 	protected double thrDiff = Double.NaN;
@@ -23,7 +23,7 @@ public class Bisectiontepper extends Stepper {
 	 * @param threshold The current threshold
 	 * @param lastThreshold The last threshold
 	 */
-	public Bisectiontepper(double threshold, double lastThreshold) {
+	public BisectionStepper(double threshold, double lastThreshold) {
 		threshold1 = threshold;
 		threshold2 = lastThreshold;
 		thrDiff = Math.abs(threshold1 - threshold2);

--- a/src/main/java/algorithms/Bisectiontepper.java
+++ b/src/main/java/algorithms/Bisectiontepper.java
@@ -1,0 +1,70 @@
+package algorithms;
+
+/**
+ * Try to converge a threshold based on an update value condition. If the
+ * update value is larger zero, the threshold is lowered by half the distance
+ * between the last thresholds. If the update value falls below zero or is not
+ * a number, the threshold is increased by such a half step.
+ *
+ * @author Tom Kazimiers
+ *
+ */
+public class Bisectiontepper extends Stepper {
+	protected double threshold1;
+	protected double threshold2;
+	protected double thrDiff = Double.NaN;
+	protected int iterations = 0;
+	protected int maxIterations = 100;
+
+	/**
+	 * Initialize the bisection stepper with a start threshold and its
+	 * last threshold
+	 *
+	 * @param threshold The current threshold
+	 * @param lastThreshold The last threshold
+	 */
+	public Bisectiontepper(double threshold, double lastThreshold) {
+		threshold1 = threshold;
+		threshold2 = lastThreshold;
+		thrDiff = Math.abs(threshold1 - threshold2);
+	}
+
+	/**
+	 * Update threshold by a bisection step. If {@value} is below zero or not
+	 * a number, the step is made upwards. If it is above zero, the stoep is
+	 * downwards.
+	 */
+	@Override
+	public void update(double value) {
+		// update working thresholds for next iteration
+		threshold2 = threshold1;
+		if (Double.NaN == value || value < 0) {
+			// we went too far, increase by the absolute half
+			threshold1 = threshold1 + thrDiff * 0.5;
+		} else if (value > 0) {
+			// as long as r > 0 we go half the way down
+			threshold1 = threshold1 - thrDiff * 0.5;
+		}
+		// Update difference to last threshold
+		thrDiff = Math.abs(threshold1 - threshold2);
+		// Update update counter
+		iterations++;
+	}
+
+	/**
+	 * Get current threshold.
+	 */
+	@Override
+	public double getValue() {
+		return threshold1;
+	}
+
+	/**
+	 * If the difference between both thresholds is < 1, we consider
+     * that as reasonable close to abort the regression.
+     * */
+	@Override
+	public boolean isFinished() {
+		return iterations > maxIterations || thrDiff < 1.0;
+	}
+}

--- a/src/main/java/algorithms/CostesSignificanceTest.java
+++ b/src/main/java/algorithms/CostesSignificanceTest.java
@@ -22,7 +22,6 @@ import net.imglib2.roi.RectangleRegionOfInterest;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 import results.ResultHandler;
 

--- a/src/main/java/algorithms/SimpleStepper.java
+++ b/src/main/java/algorithms/SimpleStepper.java
@@ -1,0 +1,66 @@
+package algorithms;
+
+/**
+ * The simple stepper decrements a start threshold with every update() call. It
+ * is finished if the update value is not a number, below zero or larger than
+ * the last value. It also stops if the decremented threshold falls below one.
+ *
+ * @author tom
+ */
+public class SimpleStepper extends Stepper {
+	double threshold;
+	double lastThreshold;
+	double currentValue;
+	double lastValue;
+	boolean finished = false;
+
+	/**
+	 * Initialize the simple sequential stepper with a starting threshold.
+	 *
+	 * @param threshold The starting threshold.
+	 */
+	public SimpleStepper(double threshold) {
+		this.threshold = threshold;
+		this.currentValue = 1.0;
+		this.lastValue = Double.MAX_VALUE;
+	}
+
+	/**
+	 * Decrement the threshold if the stepper is not marked as finished.
+	 * Rendering a stepper finished happens if {@value} is not a number,
+	 * below or equal zero or bigger than the last update value. The same
+	 * thing happens if the internal threshold falls below one.
+	 */
+	@Override
+	public void update(double value) {
+		if (!finished) {
+			// Remember current value and store new value
+			lastValue = this.currentValue;
+			currentValue = value;
+			// Decrement threshold
+			threshold = this.threshold - 1.0;
+
+			// Stop if the threshold was
+			finished = Double.NaN == value ||
+					   threshold < 1 ||
+					   value < 0.0001 ||
+					   value > lastValue;
+		}
+	}
+
+	/**
+	 * Get the current threshold.
+	 */
+	@Override
+	public double getValue() {
+		return threshold;
+	}
+
+	/**
+	 * Indicates if the stepper is marked as finished.
+	 */
+	@Override
+	public boolean isFinished() {
+		return finished;
+	}
+}

--- a/src/main/java/algorithms/Stepper.java
+++ b/src/main/java/algorithms/Stepper.java
@@ -1,0 +1,13 @@
+package algorithms;
+
+/**
+ * A stepper is used to change some value with every update() call. It should
+ * finish at some point in time.
+ *
+ * @author Tom Kazimiers
+ */
+public abstract class Stepper {
+	public abstract void update(double value);
+	public abstract double getValue();
+	public abstract boolean isFinished();
+}

--- a/src/main/java/results/EasyDisplay.java
+++ b/src/main/java/results/EasyDisplay.java
@@ -57,13 +57,18 @@ public class EasyDisplay<T extends RealType<T>> implements ResultHandler<T> {
 		// no warnings are shown in easy display
 	}
 
+	@Override
+	public void handleValue(String name, String value) {
+		textWindow.getTextPanel().appendLine(name + "\t"
+				+ value + "\n");
+	}
+
 	public void handleValue(String name, double value) {
 		handleValue(name, value, 3);
 	}
 
 	public void handleValue(String name, double value, int decimals) {
-		textWindow.getTextPanel().appendLine(name + "\t"
-				+ IJ.d2s(value, decimals) + "\n");
+		handleValue(name, IJ.d2s(value, decimals));
 	}
 
 	protected void printTextStatistics(DataContainer<T> container){

--- a/src/main/java/results/PDFWriter.java
+++ b/src/main/java/results/PDFWriter.java
@@ -109,14 +109,20 @@ public class PDFWriter<T extends RealType<T>> implements ResultHandler<T> {
 		listOfPDFTexts.add(new Paragraph("Warning! " + warning.getShortMessage() + " - " + warning.getLongMessage()));
 	}
 
+	@Override
+	public void handleValue(String name, String value) {
+		// send (output parameter name, value)  to IJ.log for scraping batch results
+		IJ.log(name + ", " + value);
+		listOfPDFTexts.add(new Paragraph(name + ": " + value));
+	}
+
 	public void handleValue(String name, double value) {
 		handleValue(name, value, 3);
 	}
 
 	public void handleValue(String name, double value, int decimals) {
 		//send (output parameter name, value)  to IJ.log for scraping batch results
-		IJ.log(name + ", "+ IJ.d2s(value, decimals));
-		listOfPDFTexts.add(new Paragraph(name + ": " + IJ.d2s(value, decimals)));
+		handleValue(name, IJ.d2s(value, decimals));
 	}
 
 	/**

--- a/src/main/java/results/ResultHandler.java
+++ b/src/main/java/results/ResultHandler.java
@@ -19,6 +19,8 @@ public interface ResultHandler<T extends RealType<T>> {
 
 	void handleWarning(Warning warning);
 
+	void handleValue(String name, String value);
+
 	void handleValue(String name, double value);
 
 	void handleValue(String name, double value, int decimals);

--- a/src/main/java/results/SingleWindowDisplay.java
+++ b/src/main/java/results/SingleWindowDisplay.java
@@ -231,6 +231,11 @@ public class SingleWindowDisplay<T extends RealType<T>> extends JFrame implement
 		warnings.add( warning );
 	}
 
+	@Override
+	public void handleValue(String name, String value) {
+		valueResults.add( new ValueResult(name, value));
+	}
+
 	public void handleValue(String name, double value) {
 		handleValue(name, value, 3);
 	}
@@ -304,7 +309,11 @@ public class SingleWindowDisplay<T extends RealType<T>> extends JFrame implement
 	    out.print("<TH>Name</TH><TH>Result</TH></TR>");
 
 	    for ( ValueResult vr : valueResults) {
-		    printTableRow(out, vr.name, vr.number, vr.decimals);
+			if (vr.isNumber) {
+				printTableRow(out, vr.name, vr.number, vr.decimals);
+			} else {
+				printTableRow(out, vr.name, vr.value);
+			}
 	    }
 
 	    out.println("</TABLE>");

--- a/src/main/java/results/ValueResult.java
+++ b/src/main/java/results/ValueResult.java
@@ -2,16 +2,25 @@ package results;
 
 /**
  * A small structure to keep decimal places information
- * with numbers along with a name.
+ * with numbers along with a name or a simple named text.
  */
 public class ValueResult {
 	public String name;
 	public double number;
 	public int decimals;
+	public String value;
+	public boolean isNumber;
 
 	public ValueResult( String name, double number, int decimals ) {
 		this.name = name;
 		this.number = number;
 		this.decimals = decimals;
+		this.isNumber = true;
+	}
+
+	public ValueResult( String name, String value) {
+		this.name = name;
+		this.value = value;
+		this.isNumber = false;
 	}
 }

--- a/src/test/java/tests/AutoThresholdRegressionTest.java
+++ b/src/test/java/tests/AutoThresholdRegressionTest.java
@@ -7,8 +7,6 @@ import net.imglib2.type.numeric.integer.UnsignedByteType;
 
 import org.junit.Test;
 
-import com.sun.jdi.FloatType;
-
 import algorithms.AutoThresholdRegression;
 import algorithms.AutoThresholdRegression.Implementation;
 import algorithms.MissingPreconditionException;

--- a/src/test/java/tests/AutoThresholdRegressionTest.java
+++ b/src/test/java/tests/AutoThresholdRegressionTest.java
@@ -10,6 +10,7 @@ import org.junit.Test;
 import com.sun.jdi.FloatType;
 
 import algorithms.AutoThresholdRegression;
+import algorithms.AutoThresholdRegression.Implementation;
 import algorithms.MissingPreconditionException;
 import algorithms.PearsonsCorrelation;
 
@@ -33,6 +34,12 @@ public class AutoThresholdRegressionTest extends ColocalisationTest {
 	 */
 	@Test
 	public void cummutativityTest() throws MissingPreconditionException {
+		_cummutativityTest(Implementation.Costes);
+		_cummutativityTest(Implementation.Bisection);
+	}
+
+	protected void _cummutativityTest(Implementation atrImplementation)
+			throws MissingPreconditionException {
 		PearsonsCorrelation<UnsignedByteType> pc1 =
 				new PearsonsCorrelation<UnsignedByteType>(
 						PearsonsCorrelation.Implementation.Fast);
@@ -41,9 +48,9 @@ public class AutoThresholdRegressionTest extends ColocalisationTest {
 						PearsonsCorrelation.Implementation.Fast);
 
 		AutoThresholdRegression<UnsignedByteType> atr1 =
-				new AutoThresholdRegression<UnsignedByteType>(pc1);
+				new AutoThresholdRegression<UnsignedByteType>(pc1, atrImplementation);
 		AutoThresholdRegression<UnsignedByteType> atr2 =
-				new AutoThresholdRegression<UnsignedByteType>(pc2);
+				new AutoThresholdRegression<UnsignedByteType>(pc2, atrImplementation);
 
 		RandomAccessibleInterval<UnsignedByteType> img1 = syntheticNegativeCorrelationImageCh1;
 		RandomAccessibleInterval<UnsignedByteType> img2 = syntheticNegativeCorrelationImageCh2;

--- a/src/test/java/tests/MandersColocalizationTest.java
+++ b/src/test/java/tests/MandersColocalizationTest.java
@@ -6,7 +6,6 @@ import algorithms.MandersColocalization.MandersResults;
 import algorithms.MissingPreconditionException;
 import net.imglib2.TwinCursor;
 import net.imglib2.type.numeric.integer.UnsignedByteType;
-import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 
 import org.junit.Test;

--- a/src/test/java/tests/TestImageAccessor.java
+++ b/src/test/java/tests/TestImageAccessor.java
@@ -31,7 +31,6 @@ import net.imglib2.type.NativeType;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 import net.imglib2.type.numeric.real.FloatType;
-import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 
 /**


### PR DESCRIPTION
This pull request adds support for different regression patterns. It also adds an alternative to the current bisection method: a simple regression that decrements values one by one, just as it is used in the Costes paper. Since this is what people are likely to expect, it is now the default. The faster bisection method is still available, but has to be selected by the user.

If there are no changes requested, I'll merge this in a couple of days into master. The pull request is only used for documentation and to allow discussion about this change.