### PR TITLE
clean up and simplify plugin results outputs  before working on new functionality

### DIFF
--- a/src/main/java/Coloc_2.java
+++ b/src/main/java/Coloc_2.java
@@ -230,7 +230,7 @@ public class Coloc_2<T extends RealType< T > & NativeType< T >> implements PlugI
 		gd.addChoice("ROI_or_mask", roisAndMasks, roisAndMasks[indexMask]);
 		//gd.addChoice("Use ROI", roiLabels, roiLabels[indexRoi]);
 
-		gd.addCheckbox("Show_\"Save_PDF\"_Dialog", autoSavePdf);
+		gd.addCheckbox("Show_Save_PDF_Dialog", autoSavePdf);
 		gd.addCheckbox("Display_Images_in_Result", displayImages);
 		gd.addCheckbox("Display_Shuffled_Images", displayShuffledCostes);
 		final Checkbox shuffleCb = (Checkbox) gd.getCheckboxes().lastElement();

--- a/src/main/java/Coloc_2.java
+++ b/src/main/java/Coloc_2.java
@@ -45,7 +45,7 @@ import net.imglib2.img.array.ArrayImgFactory;
 import net.imglib2.type.NativeType;
 import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
-import net.imglib2.util.Util;
+//import net.imglib2.util.Util;
 import net.imglib2.view.Views;
 import results.PDFWriter;
 import results.ResultHandler;

--- a/src/main/java/Coloc_2.java
+++ b/src/main/java/Coloc_2.java
@@ -71,7 +71,7 @@ import results.Warning;
  */
 
 /**
- * A plugin which does analysis colocalisation on a pair of images.
+ * A plugin which does pixel intensity correlation based colocalisation analysis on a pair of images.
  *
  * @param <T>
  */

--- a/src/main/java/Coloc_2.java
+++ b/src/main/java/Coloc_2.java
@@ -53,7 +53,7 @@ import results.SingleWindowDisplay;
 import results.Warning;
 
 /**
-   Copyright 2010, 2011 Daniel J. White, Tom Kazimiers, Johannes Schindelin
+   Copyright 2010-2015,  Daniel J. White, Tom Kazimiers, Johannes Schindelin
    and the Fiji project. Fiji is just imageJ - batteries included.
 
    This program is free software: you can redistribute it and/or modify

--- a/src/main/java/algorithms/AutoThresholdRegression.java
+++ b/src/main/java/algorithms/AutoThresholdRegression.java
@@ -15,10 +15,13 @@ import results.ResultHandler;
  * used for Person colocalisation calculation.
  */
 public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<T> {
-	/* the threshold for y-intercept to y-max to
-	 *  raise a warning about it being to high.
+	/* the threshold for ration of y-intercept : y-mean
+	 * to raise a warning about it being to high or low,
+	 * meaning far from zero. 
+	 * Don't use y-max as before, since this could be
+	 * a very high value outlier. Mean is probably more reliable. 
 	 */
-	final double warnYInterceptToYMaxRatioThreshold = 0.01;
+	final double warnYInterceptToYMeanRatioThreshold = 0.01;
 	// the slope and and intercept of the regression line
 	double autoThresholdSlope = 0.0, autoThresholdIntercept = 0.0;
 	/* The thresholds for both image channels. Pixels below a lower
@@ -28,7 +31,7 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 	 */
 	T ch1MinThreshold, ch1MaxThreshold, ch2MinThreshold, ch2MaxThreshold;
 	// additional information
-	double bToYMaxRatio = 0.0;
+	double bToYMeanRatio = 0.0;
 	//This is the Pearson's correlation we will use for further calculations
 	PearsonsCorrelation<T> pearsonsCorrellation;
 
@@ -249,12 +252,12 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 
 		autoThresholdSlope = m;
 		autoThresholdIntercept = b;
-		bToYMaxRatio = b / container.getMaxCh2();
+		bToYMeanRatio = b / container.getMeanCh2();
 
 		// add warnings if values are not in tolerance range
-		if ( Math.abs(bToYMaxRatio) > warnYInterceptToYMaxRatioThreshold ) {
-			addWarning("y-intercept high",
-				"The absolute y-intercept of the auto threshold regression line is high. Maybe you should use a ROI, maybe do a background subtraction in both channels.");
+		if ( Math.abs(bToYMeanRatio) > warnYInterceptToYMeanRatioThreshold ) {
+			addWarning("y-intercept far from zero",
+				"The ratio of the y-intercept of the auto threshold regression line to the mean value of Channel 2 is high. This means the y-intercept is far from zero, implying a significant positive or negative zero offset in the image data intensities. Maybe you should use a ROI. Maybe do a background subtraction in both channels. Make sure you didn't clip off the low intensities to zero. This might not affect Pearson's correlation values very much, but might harm other results.");
 		}
 
 		// add warning if threshold is above the image mean
@@ -270,7 +273,7 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 		// add warnings if values are below lowest pixel value of images
 		if ( ch1ThreshMax < container.getMinCh1() || ch2ThreshMax < container.getMinCh2() ) {
 			addWarning("thresholds too low",
-				"The auto threshold method could not find a positive threshold.");
+				"The auto threshold method could not find a positive threshold, so thresholded results are meaningless.");
 		}
 	}
 
@@ -288,17 +291,17 @@ public class AutoThresholdRegression<T extends RealType< T >> extends Algorithm<
 
 		handler.handleValue( "m (slope)", autoThresholdSlope , 2 );
 		handler.handleValue( "b (y-intercept)", autoThresholdIntercept, 2 );
-		handler.handleValue( "b to y-max ratio", bToYMaxRatio, 2 );
+		handler.handleValue( "b to y-mean ratio", bToYMeanRatio, 2 );
 		handler.handleValue( "Ch1 Max Threshold", ch1MaxThreshold.getRealDouble(), 2);
 		handler.handleValue( "Ch2 Max Threshold", ch2MaxThreshold.getRealDouble(), 2);
 	}
 
-	public double getBToYMaxRatio() {
-		return bToYMaxRatio;
+	public double getBToYMeanRatio() {
+		return bToYMeanRatio;
 	}
 
 	public double getWarnYInterceptToYMaxRatioThreshold() {
-		return warnYInterceptToYMaxRatioThreshold;
+		return warnYInterceptToYMeanRatioThreshold;
 	}
 
 	public double getAutoThresholdSlope() {

--- a/src/main/java/algorithms/InputCheck.java
+++ b/src/main/java/algorithms/InputCheck.java
@@ -29,6 +29,9 @@ public class InputCheck<T extends RealType< T >> extends Algorithm<T> {
 	double saturatedRatioCh1;
 	// the saturated pixel ratio of channel 2
 	double saturatedRatioCh2;
+	
+	// the coloc job name
+	String colocJobName;
 
 	public InputCheck() {
 		super("input data check");
@@ -90,7 +93,10 @@ public class InputCheck<T extends RealType< T >> extends Algorithm<T> {
 		zeroZeroPixelRatio = zeroZeroRatio * 100.0;
 		saturatedRatioCh1 = ch1SaturatedRatio * 100.0;
 		saturatedRatioCh2 = ch2SaturatedRatio * 100.0;
-
+		
+		// get the coloc job name so the ResultsHandler implementation can have it. 
+		colocJobName = container.getJobName();
+		
 		// add warnings if values are not in tolerance range
 		if ( Math.abs(zeroZeroRatio) > maxZeroZeroRatio ) {
 
@@ -113,6 +119,16 @@ public class InputCheck<T extends RealType< T >> extends Algorithm<T> {
 	@Override
 	public void processResults(ResultHandler<T> handler) {
 		super.processResults(handler);
+		
+		// Here is a good place to have the coloc job name handled by the
+		// ResultsHandler implementation in use, since this class is always run.
+		// I'm going to abuse a ValueResult for this,
+		// even though the jobName has no numerical value...only it's String name...
+		// because i want ot keep the jobName close to all the value results
+		// so they get shown together by whatever implementation of ResultsHandler.
+		handler.handleValue(colocJobName, -1.0, 0);
+		
+		// Make the ResultsHander implementation deal with the results. 
 		handler.handleValue("% zero-zero pixels", zeroZeroPixelRatio, 2);
 		handler.handleValue("% saturated ch1 pixels", saturatedRatioCh1, 2);
 		handler.handleValue("% saturated ch2 pixels", saturatedRatioCh2, 2);

--- a/src/main/java/algorithms/InputCheck.java
+++ b/src/main/java/algorithms/InputCheck.java
@@ -14,6 +14,8 @@ import results.ResultHandler;
  * data. For instance: Is the percentage of zero-zero or 
  * saturated pixels too high?
  * Also, we get basic image properties / stats from imglib2, 
+ * and also the colocalization job name from the DataContainer
+ * and allow implementations of ResultHandler to report them.
  */
 public class InputCheck<T extends RealType< T >> extends Algorithm<T> {
 	/* the maximum allowed ratio between zero-zero and
@@ -116,10 +118,7 @@ public class InputCheck<T extends RealType< T >> extends Algorithm<T> {
 		zeroZeroPixelRatio = zeroZeroRatio * 100.0;
 		saturatedRatioCh1 = ch1SaturatedRatio * 100.0;
 		saturatedRatioCh2 = ch2SaturatedRatio * 100.0;
-		
-		// get the coloc job name so the ResultsHandler implementation can have it. 
-		colocJobName = container.getJobName();
-		
+
 		// add warnings if values are not in tolerance range
 		if ( Math.abs(zeroZeroRatio) > maxZeroZeroRatio ) {
 

--- a/src/main/java/algorithms/PercentOverlapThresholdedPixelsAndIntensity.java
+++ b/src/main/java/algorithms/PercentOverlapThresholdedPixelsAndIntensity.java
@@ -1,0 +1,82 @@
+package algorithms;
+
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.algorithm.math.ImageStatistics;
+
+/**
+ * This algorithm calculates Percent Overlap
+ * in terms of pixels and intensity above threshold 
+ * for both of the two channels,
+ * from the point of view of each channel with respect to the other.
+ * 
+ * @author Dan White, GE Healthcare
+ * 
+ * Here follows Notes from section 6.3 of 
+ * http://www.uhnresearch.ca/facilities/wcif/imagej/colour_analysis.htm
+ * which define the output of the depreciated Colocalization Threshold plugin 
+ * which we reimplement here
+ * 
+ *  Number of colocalised voxels – Ncoloc
+ *  This is the number of voxels which have both channel 1 and channel 2 
+ *  intensities above threshold (i.e., the number of pixels in the yellow area 
+ *  of the scatterplot).
+ *  
+ *  %Image volume colocalised – %Volume 
+ *  This is the percentage of voxels which have both 
+ *  channel 1 and channel 2 intensities above threshold,
+ *  expressed as a percentage of the total number of
+ *  pixels in the image (including zero-zero pixels);
+ *  in other words, the number of pixels in the
+ *  scatterplot’s yellow area ÷  total number of pixels in the scatter plot
+ *  (the Red + Green + Blue + Yellow areas). 
+ *  
+ *  %Voxels Colocalised – %Ch1 Vol; %Ch2 Vol 
+ *  This generates a value for each channel.
+ *  This is the number of voxels for each channel which have both
+ *  channel 1 and channel 2 intensities above threshold,
+ *  expressed as a percentage of the total number of voxels for
+ *  each channel above their respective thresholds; in other words,
+ *  for channel 1 (along the x-axis), this equals the
+ *  (the number of pixels in the Yellow area) ÷ (the number of pixels in the Blue + Yellow areas).
+ *  For channel 2 this is calculated as follows:
+ *  (the number of pixels in the Yellow area) ÷ (the number of pixels in the Red + Yellow areas). 
+ *  
+ *  %Intensity Colocalised – %Ch1 Int; %Ch2 Int
+ *  This generates a value for each channel.
+ *  For channel 1, this value is equal to the sum of the pixel intensities,
+ *  with intensities above both channel 1 and channel 2 thresholds expressed as
+ *  a percentage of the sum of all channel 1 intensities;
+ *  in other words, it is calculated as follows:
+ *  (the sum of channel 1 pixel intensities in the Yellow area) ÷ (the sum of channel 1 pixels intensities in the Red + Green + Blue + Yellow areas).
+ *  
+ *  %Intensities above threshold colocalised – %Ch1 Int > thresh; %Ch2 Int > thresh
+ *  This generates a value for each channel.
+ *  For channel 1, this value is equal to the sum of the
+ *  pixel intensities with intensities above both channel 1 and channel 2 thresholds
+ *  expressed as a  percentage of the sum of all channel 1 intensities above the
+ *  threshold for channel 1.
+ *  In other words, it is calculated as follows:
+ *  (the sum of channel 1 pixel intensities in the Yellow area) ÷ (sum of channel 1 pixels intensities in the Blue + Yellow area)
+ *
+ */
+public class PercentOverlapThresholdedPixelsAndIntensity extends Algorithm<T> {
+
+/**
+ * TODO: - implement it all	;-)
+ * 
+ * Must have a check to see if the is a Mask, if not refuse to run, and thow an error. 
+ * Not just a warning, rather a refusal to run 
+ * Running these measures without a ROI will nearly always generate nonsesne as the amount of foreground
+ * always varies... and even when all the images should be analysed, its easy enough to be explicit 
+ * amout thats bing the case by setting the mask to by all pixels. 
+ * 
+ * 4 methods, all talking a mask, as these measures only make sense with a region of interest,
+ * % intensity  and %pixels above thresholds from perspective of either channel or the other. 
+ * 
+ * 1 method to get number of colcoalized pixels in total.
+ * total no of pixels in the ROI (or rather the mask) is alrealdy calculated in ImageStatistics
+ * and the DataContainer now grabs that number as a long, so we can use it here. 
+ */
+	
+	
+}

--- a/src/main/java/algorithms/PercentOverlapThresholdedPixelsAndIntensity.java
+++ b/src/main/java/algorithms/PercentOverlapThresholdedPixelsAndIntensity.java
@@ -64,17 +64,17 @@ public class PercentOverlapThresholdedPixelsAndIntensity extends Algorithm<T> {
 /**
  * TODO: - implement it all	;-)
  * 
- * Must have a check to see if the is a Mask, if not refuse to run, and thow an error. 
+ * Must have a check to see if the is a Mask, if not refuse to run, and throw an error. 
  * Not just a warning, rather a refusal to run 
- * Running these measures without a ROI will nearly always generate nonsesne as the amount of foreground
- * always varies... and even when all the images should be analysed, its easy enough to be explicit 
- * amout thats bing the case by setting the mask to by all pixels. 
+ * Running these measures without a ROI will nearly always generate nonsense as the amount of foreground
+ * always varies... and even when the whole image should be analysed, its easy enough to be explicit 
+ * about thats being the case by setting the mask to be all pixels. 
  * 
  * 4 methods, all talking a mask, as these measures only make sense with a region of interest,
  * % intensity  and %pixels above thresholds from perspective of either channel or the other. 
  * 
  * 1 method to get number of colcoalized pixels in total.
- * total no of pixels in the ROI (or rather the mask) is alrealdy calculated in ImageStatistics
+ * total no of pixels in the ROI (or rather the mask) is already calculated in ImageStatistics
  * and the DataContainer now grabs that number as a long, so we can use it here. 
  */
 	

--- a/src/main/java/gadgets/DataContainer.java
+++ b/src/main/java/gadgets/DataContainer.java
@@ -16,7 +16,7 @@ import net.imglib2.type.numeric.RealType;
 
 /**
  * The DataContainer keeps all the source data,
- * pre-processing results and
+ * jobName, pre-processing results and
  * algorithm results that have been computed. 
  * It allows a client to get most of its content
  * and makes the source image and channel information
@@ -34,6 +34,8 @@ public class DataContainer<T extends RealType< T >> {
 	RandomAccessibleInterval<T> sourceImage1, sourceImage2;
 	// The names of the two source images
 	String sourceImage1Name, sourceImage2Name;
+	// The name of the colocalisation run job
+	public String jobName;
 	// The mask for the images
 	RandomAccessibleInterval<BitType> mask;
 	// Type of the used mask
@@ -69,6 +71,8 @@ public class DataContainer<T extends RealType< T >> {
 		sourceImage2 = src2;
 		sourceImage1Name = name1;
 		sourceImage2Name = name2;
+		// create a jobName so ResultHandler instances can all use the same object for the job name. 
+		jobName = "Colocalization_of_" + name1 + "_versus_" + name2;
 		// create a mask that is true at all pixels.
 		final long[] dims = new long[src1.numDimensions()];
 		src1.dimensions(dims);
@@ -114,6 +118,8 @@ public class DataContainer<T extends RealType< T >> {
 		this.ch2 = ch2;
 		sourceImage1Name = name1;
 		sourceImage2Name = name2;
+		// create a jobName so ResultHandler instances can all use the same object for the job name. 
+		jobName = "Colocalization_of_" + name1 + "_versus_" + name2;
 
 		final int numDims = src1.numDimensions();
 		maskBBOffset = new long[numDims];
@@ -152,6 +158,8 @@ public class DataContainer<T extends RealType< T >> {
 		sourceImage2 = src2;
 		sourceImage1Name = name1;
 		sourceImage1Name = name2;
+		// create a jobName so ResultHandler instances can all use the same object for the job name. 
+		jobName = "Colocalization_of_" + name1 + "_versus_" + name2;
 		
 		final int numDims = src1.numDimensions();
 		final long[] dim = new long[numDims];
@@ -255,6 +263,10 @@ public class DataContainer<T extends RealType< T >> {
 
 	public String getSourceImage2Name() {
 		return sourceImage2Name;
+	}
+	
+	public String getJobName() {
+		return jobName;
 	}
 
 	public RandomAccessibleInterval<BitType> getMask() {

--- a/src/main/java/gadgets/DataContainer.java
+++ b/src/main/java/gadgets/DataContainer.java
@@ -15,10 +15,12 @@ import net.imglib2.type.logic.BitType;
 import net.imglib2.type.numeric.RealType;
 
 /**
- * The DataContainer keeps all the source data, pre-processing results and
- * algorithms that have been executed. It allows a client to get most its
- * content and makes the source image and channel information available
- * to a client.
+ * The DataContainer keeps all the source data,
+ * pre-processing results and
+ * algorithm results that have been computed. 
+ * It allows a client to get most of its content
+ * and makes the source image and channel information
+ * available to a client.
 
  * @param <T>
  */
@@ -50,10 +52,10 @@ public class DataContainer<T extends RealType< T >> {
 	List< Algorithm<T> > algorithms = new ArrayList< Algorithm<T> >();
 
 	/**
-	 * Creates a new {@link DataContainer} for a specific set of image and
-	 * channel combination.
+	 * Creates a new {@link DataContainer} for a
+	 * specific image channel combination.
 	 * We create default thresholds here that are the max and min of the
-	 * type of the source image channels.
+	 * data type of the source image channels.
 	 *
 	 * @param src1 The channel one image source
 	 * @param src2 The channel two image source
@@ -67,7 +69,7 @@ public class DataContainer<T extends RealType< T >> {
 		sourceImage2 = src2;
 		sourceImage1Name = name1;
 		sourceImage2Name = name2;
-		// create a mask that is everywhere valid
+		// create a mask that is true at all pixels.
 		final long[] dims = new long[src1.numDimensions()];
 		src1.dimensions(dims);
 		mask = MaskFactory.createMask(dims, true);

--- a/src/main/java/gadgets/DataContainer.java
+++ b/src/main/java/gadgets/DataContainer.java
@@ -40,7 +40,8 @@ public class DataContainer<T extends RealType< T >> {
 	RandomAccessibleInterval<BitType> mask;
 	// Type of the used mask
 	protected MaskType maskType;
-
+	// the hash code integer of the mask object
+	int maskHash;
 	// The channels of the source images that the result relate to
 	int ch1, ch2;
 	// The masks bounding box
@@ -53,6 +54,11 @@ public class DataContainer<T extends RealType< T >> {
 	// a list that contains all added algorithms
 	List< Algorithm<T> > algorithms = new ArrayList< Algorithm<T> >();
 
+	
+	
+	// why is there so much copy paste in the next three method implementations of DataContainer???
+	
+	
 	/**
 	 * Creates a new {@link DataContainer} for a
 	 * specific image channel combination.
@@ -71,8 +77,7 @@ public class DataContainer<T extends RealType< T >> {
 		sourceImage2 = src2;
 		sourceImage1Name = name1;
 		sourceImage2Name = name2;
-		// create a jobName so ResultHandler instances can all use the same object for the job name. 
-		jobName = "Colocalization_of_" + name1 + "_versus_" + name2;
+		
 		// create a mask that is true at all pixels.
 		final long[] dims = new long[src1.numDimensions()];
 		src1.dimensions(dims);
@@ -86,7 +91,12 @@ public class DataContainer<T extends RealType< T >> {
 		mask.dimensions(maskBBSize);
 		// indicated that there is actually no mask
 		maskType = MaskType.None;
-
+		
+		maskHash = mask.hashCode();
+		// create a jobName so ResultHandler instances can all use the same object for the job name. 
+		jobName = "Colocalization_of_" + name1 + "_versus_" + name2 + "_" + maskHash;
+		
+		
 		calculateStatistics();
 	}
 
@@ -118,9 +128,7 @@ public class DataContainer<T extends RealType< T >> {
 		this.ch2 = ch2;
 		sourceImage1Name = name1;
 		sourceImage2Name = name2;
-		// create a jobName so ResultHandler instances can all use the same object for the job name. 
-		jobName = "Colocalization_of_" + name1 + "_versus_" + name2;
-
+		
 		final int numDims = src1.numDimensions();
 		maskBBOffset = new long[numDims];
 		maskBBSize = new long[numDims];
@@ -133,6 +141,10 @@ public class DataContainer<T extends RealType< T >> {
 		adjustRoiOffset(offset, maskBBOffset, dim);
 		adjustRoiSize(size, maskBBSize, dim, maskBBOffset);
 
+		maskHash = mask.hashCode();
+		// create a jobName so ResultHandler instances can all use the same object for the job name. 
+		jobName = "Colocalization_of_" + name1 + "_versus_" + name2 + "_" + maskHash;
+		
 		calculateStatistics();
 	}
 
@@ -158,8 +170,6 @@ public class DataContainer<T extends RealType< T >> {
 		sourceImage2 = src2;
 		sourceImage1Name = name1;
 		sourceImage1Name = name2;
-		// create a jobName so ResultHandler instances can all use the same object for the job name. 
-		jobName = "Colocalization_of_" + name1 + "_versus_" + name2;
 		
 		final int numDims = src1.numDimensions();
 		final long[] dim = new long[numDims];
@@ -170,7 +180,7 @@ public class DataContainer<T extends RealType< T >> {
 		adjustRoiOffset(offset, roiOffset, dim);
 		adjustRoiSize(size, roiSize, dim, roiOffset);
 
-		// create a mask that is everywhere valid
+		// create a mask that is valid everywhere
 		mask = MaskFactory.createMask(dim, roiOffset, roiSize);
 		maskBBOffset = roiOffset.clone();
 		maskBBSize = roiSize.clone();
@@ -180,6 +190,10 @@ public class DataContainer<T extends RealType< T >> {
 		this.ch1 = ch1;
 		this.ch2 = ch2;
 
+		maskHash = mask.hashCode();
+		// create a jobName so ResultHandler instances can all use the same object for the job name. 
+		jobName = "Colocalization_of_" + name1 + "_versus_" + name2 + "_" + maskHash;
+		
 		calculateStatistics();
 	}
 

--- a/src/main/java/gadgets/DataContainer.java
+++ b/src/main/java/gadgets/DataContainer.java
@@ -26,7 +26,8 @@ public class DataContainer<T extends RealType< T >> {
 	// enumeration of different mask types
 	public enum MaskType { Regular, Irregular, None };
 	// some general image statistics
-	double meanCh1, meanCh2, minCh1, maxCh1, minCh2, maxCh2, integralCh1, integralCh2;
+	double meanCh1, meanCh2, minCh1, maxCh1, minCh2, maxCh2, integralCh1, integralCh2; 
+	long numberOfPixelsInMask;
 	// The source images that the results are based on
 	RandomAccessibleInterval<T> sourceImage1, sourceImage2;
 	// The names of the two source images
@@ -181,6 +182,7 @@ public class DataContainer<T extends RealType< T >> {
 		maxCh2 = ImageStatistics.getImageMax(sourceImage2, mask).getRealDouble();
 		integralCh1 = ImageStatistics.getImageIntegral(sourceImage1, mask);
 		integralCh2 = ImageStatistics.getImageIntegral(sourceImage2, mask);
+		numberOfPixelsInMask = ImageStatistics.getNumPixels(mask);
 	}
 
 	/**
@@ -231,6 +233,10 @@ public class DataContainer<T extends RealType< T >> {
 
 	public MaskType getMaskType() {
 		return maskType;
+	}
+	
+	public Long getNumberOfPixelsInMask() {
+		return numberOfPixelsInMask;
 	}
 
 	public RandomAccessibleInterval<T> getSourceImage1() {

--- a/src/main/java/results/PDFWriter.java
+++ b/src/main/java/results/PDFWriter.java
@@ -170,8 +170,10 @@ public class PDFWriter<T extends RealType<T>> implements ResultHandler<T> {
 	public void process() {
 		try {
 			// produce default name
-			String nameCh1 = container.getSourceImage1Name();
-			String nameCh2 = container.getSourceImage2Name();
+			// don't need to do it here anymore, as DataContainer has the jobName
+			// made from the image names already. 
+			//String nameCh1 = container.getSourceImage1Name();
+			//String nameCh2 = container.getSourceImage2Name();
 
 			// Use the getJobName() in DataContainer for the job name.
 			String jobName =  container.getJobName();
@@ -180,7 +182,11 @@ public class PDFWriter<T extends RealType<T>> implements ResultHandler<T> {
 			 * information to the jobName.
 			 */
 			if (container.getMaskType() != MaskType.None) {
-				jobName += "_mask_"+ (succeededPrints + 1);
+				// maskHash is now used as the mask or ROI unique ID in the jobName
+				// but we can still increment and use succeededPrints
+				// at the end of the filename for PDFs when there is a mask. 
+				//jobName += "_mask_"+ (succeededPrints + 1);
+				jobName += (succeededPrints + 1);
 			}
 			// get the path to the file we are about to create
 			SaveDialog sd = new SaveDialog("Save as PDF", jobName, ".pdf");

--- a/src/main/java/results/PDFWriter.java
+++ b/src/main/java/results/PDFWriter.java
@@ -171,29 +171,34 @@ public class PDFWriter<T extends RealType<T>> implements ResultHandler<T> {
 			String nameCh1 = container.getSourceImage1Name();
 			String nameCh2 = container.getSourceImage2Name();
 
-			////send names of the 2 images to IJ.log for scraping batch results
-			IJ.log("ImageNames" + ", " + nameCh1 + ", " + nameCh2);
+			//send names of the 2 images to IJ.log for scraping batch results
+			// This is done below, no need to do it here!
+			// THis has nothing to do with the pdf writer!!!
+			//IJ.log("ImageNames" + ", " + nameCh1 + ", " + nameCh2);
 
-			String name =  "coloc_" + nameCh1 + "_" + nameCh2;
+			// Use the getJobName() in DataContainer for the job name.
+			String jobName =  container.getJobName();
+			
 			/* If a mask is in use, add a counter
-			 * information to the name.
+			 * information to the jobName.
 			 */
 			if (container.getMaskType() != MaskType.None) {
-				name += "_mask_"+ (succeededPrints + 1);
+				jobName += "_mask_"+ (succeededPrints + 1);
 			}
 			// get the path to the file we are about to create
-			SaveDialog sd = new SaveDialog("Save as PDF", name, ".pdf");
-			name = sd.getFileName();
+			SaveDialog sd = new SaveDialog("Save as PDF", jobName, ".pdf");
+			// update jobName id the user changes it in the save file dialog.
+			jobName = sd.getFileName();
 			String directory = sd.getDirectory();
-			// make sure we got what we need
-			if ((name == null) || (directory == null)) {
+			// make sure we have what we need next
+			if ((jobName == null) || (directory == null)) {
 				return;
 			}
-			String path = directory+name;
+			String path = directory+jobName;
 			// create a new iText Document and add date and title
 			document = new Document(isLetter ? PageSize.LETTER : PageSize.A4);
 			document.addCreationDate();
-			document.addTitle(name);
+			document.addTitle(jobName);
 			// get a writer object to do the actual output
 			writer = PdfWriter.getInstance(document, new FileOutputStream(path));
 			document.open();
@@ -203,7 +208,7 @@ public class PDFWriter<T extends RealType<T>> implements ResultHandler<T> {
 			}
 
 			//send name of analysis job to IJ.log for scraping batch results
-			IJ.log("ColocAnalysisJobName" + ", " + name);
+			IJ.log("ColocAnalysisJobName" + ", " + jobName);
 
 			//iterate over all produced text objects
 			for (Paragraph p : listOfPDFTexts) {

--- a/src/main/java/results/PDFWriter.java
+++ b/src/main/java/results/PDFWriter.java
@@ -171,11 +171,6 @@ public class PDFWriter<T extends RealType<T>> implements ResultHandler<T> {
 			String nameCh1 = container.getSourceImage1Name();
 			String nameCh2 = container.getSourceImage2Name();
 
-			//send names of the 2 images to IJ.log for scraping batch results
-			// This is done below, no need to do it here!
-			// THis has nothing to do with the pdf writer!!!
-			//IJ.log("ImageNames" + ", " + nameCh1 + ", " + nameCh2);
-
 			// Use the getJobName() in DataContainer for the job name.
 			String jobName =  container.getJobName();
 			
@@ -187,7 +182,7 @@ public class PDFWriter<T extends RealType<T>> implements ResultHandler<T> {
 			}
 			// get the path to the file we are about to create
 			SaveDialog sd = new SaveDialog("Save as PDF", jobName, ".pdf");
-			// update jobName id the user changes it in the save file dialog.
+			// update jobName if the user changes it in the save file dialog.
 			jobName = sd.getFileName();
 			String directory = sd.getDirectory();
 			// make sure we have what we need next
@@ -207,8 +202,6 @@ public class PDFWriter<T extends RealType<T>> implements ResultHandler<T> {
 				addImage(img);
 			}
 
-			//send name of analysis job to IJ.log for scraping batch results
-			IJ.log("ColocAnalysisJobName" + ", " + jobName);
 
 			//iterate over all produced text objects
 			for (Paragraph p : listOfPDFTexts) {

--- a/src/main/java/results/PDFWriter.java
+++ b/src/main/java/results/PDFWriter.java
@@ -197,12 +197,16 @@ public class PDFWriter<T extends RealType<T>> implements ResultHandler<T> {
 			// get a writer object to do the actual output
 			writer = PdfWriter.getInstance(document, new FileOutputStream(path));
 			document.open();
+			
+			// write the colocalization job name at the top of the PDF file as a title
+			Paragraph titlePara = new Paragraph(jobName);
+			document.add(titlePara);
+			
 			// iterate over all produced images
 			for (com.itextpdf.text.Image img : listOfPDFImages) {
 				addImage(img);
 			}
-
-
+			
 			//iterate over all produced text objects
 			for (Paragraph p : listOfPDFTexts) {
 				document.add(p);

--- a/src/main/java/results/PDFWriter.java
+++ b/src/main/java/results/PDFWriter.java
@@ -114,8 +114,10 @@ public class PDFWriter<T extends RealType<T>> implements ResultHandler<T> {
 	}
 
 	public void handleValue(String name, double value, int decimals) {
-		//send (output parameter name, value)  to IJ.log for scraping batch results
-		IJ.log(name + ", "+ IJ.d2s(value, decimals));
+		//Dont send (output parameter name, value)  to IJ.log for scraping batch results,
+		// because the default ResultHandler should always do it, 
+		// in this case SingleWindowDisplay now does it. 
+		//IJ.log(name + ", "+ IJ.d2s(value, decimals));
 		listOfPDFTexts.add(new Paragraph(name + ": " + IJ.d2s(value, decimals)));
 	}
 

--- a/src/main/java/results/SingleWindowDisplay.java
+++ b/src/main/java/results/SingleWindowDisplay.java
@@ -314,23 +314,6 @@ public class SingleWindowDisplay<T extends RealType<T>> extends JFrame implement
 	    }
 
 	    out.println("</TABLE>");
-
-	    // print some image statistics
-	    out.print("<H1>Image statistics</H1>");
-	    out.print("<TABLE>");
-	    printTableRow(out, "Min channel 1",  dataContainer.getMinCh1());
-	    printTableRow(out, "Max channel 1",  dataContainer.getMaxCh1());
-	    printTableRow(out, "Mean channel 1", dataContainer.getMeanCh1());
-	    printTableRow(out, "Channel 1, integrated intensity of pixels in ROI (Mask)", dataContainer.getIntegralCh1());
-
-	    printTableRow(out, "Min channel 2",  dataContainer.getMinCh2());
-	    printTableRow(out, "Max channel 2",  dataContainer.getMaxCh2());
-	    printTableRow(out, "Mean channel 2", dataContainer.getMeanCh2());
-	    printTableRow(out, "Channel 2, integrated intensity of pixels in ROI (Mask)", dataContainer.getIntegralCh2());
-	    
-	    printTableRow(out, "No. of pixels in ROI (Mask)", dataContainer.getNumberOfPixelsInMask());
-
-	    out.println("</TABLE>");
 	    out.print("</html>");
 	    out.close();
 

--- a/src/main/java/results/SingleWindowDisplay.java
+++ b/src/main/java/results/SingleWindowDisplay.java
@@ -102,9 +102,10 @@ public class SingleWindowDisplay<T extends RealType<T>> extends JFrame implement
 	protected DataContainer<T> dataContainer = null;
 
 	public SingleWindowDisplay(DataContainer<T> container, PDFWriter<T> pdfWriter){
-		super("Colocalisation " + container.getSourceImage1Name() + " vs " +
-				container.getSourceImage2Name());
-
+		
+		// Use the getJobName() in DataContainer for the SingleWindowDisplay title bar.
+		super(container.getJobName());
+		
 		setPreferredSize(new Dimension(WIN_WIDTH, WIN_HEIGHT));
 
 		// save a reference to the container

--- a/src/main/java/results/SingleWindowDisplay.java
+++ b/src/main/java/results/SingleWindowDisplay.java
@@ -319,6 +319,8 @@ public class SingleWindowDisplay<T extends RealType<T>> extends JFrame implement
 	    printTableRow(out, "Min channel 2", dataContainer.getMinCh2());
 	    printTableRow(out, "Max channel 2", dataContainer.getMaxCh2());
 	    printTableRow(out, "Mean channel 2", dataContainer.getMeanCh2());
+	    
+	    printTableRow(out, "No. of pixels in Mask", dataContainer.getNumberOfPixelsInMask());
 
 	    out.println("</TABLE>");
 

--- a/src/main/java/results/SingleWindowDisplay.java
+++ b/src/main/java/results/SingleWindowDisplay.java
@@ -203,9 +203,12 @@ public class SingleWindowDisplay<T extends RealType<T>> extends JFrame implement
 					dataContainer.getSourceImage2(),
 					dataContainer.getSourceImage2Name() ) );
 		}
-		// create HTML table
-		makeHtmlText();
-		// set up the GUI
+		
+		// create HTML table.... dont need to do it here, as makeHtmlText()
+		// is run in the setup() method! This caused duplication of results in IJ.log
+		// makeHtmlText();
+		
+		// set up the GUI, which runs makeHtmlText() for the value results formatting. 
 		setup();
 		// display the first image available, if any
 		if (listOfImages.size() > 0) {
@@ -306,6 +309,8 @@ public class SingleWindowDisplay<T extends RealType<T>> extends JFrame implement
 
 	    for ( ValueResult vr : valueResults) {
 		    printTableRow(out, vr.name, vr.number, vr.decimals);
+		    // Spit results to the IJ log. 
+		    IJ.log(vr.name + ", " + IJ.d2s(vr.number, vr.decimals));
 	    }
 
 	    out.println("</TABLE>");

--- a/src/main/java/results/SingleWindowDisplay.java
+++ b/src/main/java/results/SingleWindowDisplay.java
@@ -316,14 +316,13 @@ public class SingleWindowDisplay<T extends RealType<T>> extends JFrame implement
 	    printTableRow(out, "Max channel 1",  dataContainer.getMaxCh1());
 	    printTableRow(out, "Mean channel 1", dataContainer.getMeanCh1());
 
-	    printTableRow(out, "Min channel 2", dataContainer.getMinCh2());
-	    printTableRow(out, "Max channel 2", dataContainer.getMaxCh2());
+	    printTableRow(out, "Min channel 2",  dataContainer.getMinCh2());
+	    printTableRow(out, "Max channel 2",  dataContainer.getMaxCh2());
 	    printTableRow(out, "Mean channel 2", dataContainer.getMeanCh2());
 	    
-	    printTableRow(out, "No. of pixels in Mask", dataContainer.getNumberOfPixelsInMask());
+	    printTableRow(out, "No. of pixels in ROI (Mask)", dataContainer.getNumberOfPixelsInMask());
 
 	    out.println("</TABLE>");
-
 	    out.print("</html>");
 	    out.close();
 

--- a/src/main/java/results/SingleWindowDisplay.java
+++ b/src/main/java/results/SingleWindowDisplay.java
@@ -315,10 +315,12 @@ public class SingleWindowDisplay<T extends RealType<T>> extends JFrame implement
 	    printTableRow(out, "Min channel 1",  dataContainer.getMinCh1());
 	    printTableRow(out, "Max channel 1",  dataContainer.getMaxCh1());
 	    printTableRow(out, "Mean channel 1", dataContainer.getMeanCh1());
+	    printTableRow(out, "Channel 1, integrated intensity of pixels in ROI (Mask)", dataContainer.getIntegralCh1());
 
 	    printTableRow(out, "Min channel 2",  dataContainer.getMinCh2());
 	    printTableRow(out, "Max channel 2",  dataContainer.getMaxCh2());
 	    printTableRow(out, "Mean channel 2", dataContainer.getMeanCh2());
+	    printTableRow(out, "Channel 2, integrated intensity of pixels in ROI (Mask)", dataContainer.getIntegralCh2());
 	    
 	    printTableRow(out, "No. of pixels in ROI (Mask)", dataContainer.getNumberOfPixelsInMask());
 

--- a/src/test/java/tests/PercentOverlapThresholdedPixelsAndIntensityTest.java
+++ b/src/test/java/tests/PercentOverlapThresholdedPixelsAndIntensityTest.java
@@ -1,0 +1,40 @@
+
+package tests;
+
+import static org.junit.Assert.assertEquals;
+import algorithms.MissingPreconditionException;
+import algorithms.PercentOverlapThresholdedPixelsAndIntensity;
+import gadgets.MaskFactory;
+import net.imglib2.RandomAccessibleInterval;
+import net.imglib2.TwinCursor;
+import net.imglib2.type.logic.BitType;
+import net.imglib2.type.numeric.integer.UnsignedByteType;
+import net.imglib2.type.numeric.real.FloatType;
+import net.imglib2.view.Views;
+
+
+/**
+ * These are JUnit 4 test cases for the algorithm that calculates Percent Overlap
+ * in terms of pixels and intensity above threshold 
+ * (from the point of view of each channel with respect to the other)
+ * for both of the two channels.  
+ * 
+ * @author Dan White, GE Healthcare
+ */
+
+
+public class PercentOverlapThresholdedPixelsAndIntensityTest extends ColocalisationTest {
+
+	/**
+	 * Set of tests for if the % overlap of pixels and intensity 
+	 * (from the point of view of each channel with respect to the other)
+	 * for the Manders test images are close enough to correct, 
+	 * compared to what the depreciated Colocalisation Threshold plugin calculates 
+	 */
+	
+	@Test
+	public void test() throws MissingPreconditionException {
+		fail("Not yet implemented");
+	}
+
+}


### PR DESCRIPTION
Hi guys,
here are a bunch of fairly trivial clean up changes, and a couple of more weighty ones.

I made the three ways results can be expressed to the user show all the same results, no matter which way of seeing the results they choose:    I added all results/stats computed and displayed so far into the DataContainer, so all ResultsHandler implementations (SingleWindowDisplay, PFFWriter and IJ.log) just use all the same results values, including a new one called jobName, that uses a unique ID from the imglib2 maskHash int value. results from different masks or ROIs in the same imput images will get different filenames/titles/top line of results. 

I changed one of the warnings in the autothreshold algorithm to be more robust, hopefully, and added detail to the warning text. 

I outlined the approach for a new algorithm to add (% Coloc by intensity and/or pixels) with some dead code files and a dead code unit test ( implementing it all.... that's my next task)

I wrote a bunch of TODOs in the imagej.net/Coloc_2 wiki page. Should i use the imsgeJ2 issue tracker instead?

I tested my changes manually... its mostly GUI stuff i could not easily make  unit test for? Would that be appropriate for these kinds of things?