### PR TITLE
Added warnings in case of negative pixel values

### DIFF
--- a/src/main/java/algorithms/Histogram2D.java
+++ b/src/main/java/algorithms/Histogram2D.java
@@ -191,6 +191,8 @@ public class Histogram2D<T extends RealType< T >> extends Algorithm<T> {
 		final RandomAccess<LongType> histogram2DCursor =
 			plotImage.randomAccess();
 
+		long ignoredPixelCount = 0;
+
 		// iterate over images
 		long[] pos = new long[ plotImage.numDimensions() ];
 		while (cursor.hasNext()) {
@@ -202,15 +204,26 @@ public class Histogram2D<T extends RealType< T >> extends Algorithm<T> {
 			 */
 			pos[0] = getXValue(ch1, ch1BinWidth, ch2, ch2BinWidth);
 			pos[1] = getYValue(ch1, ch1BinWidth, ch2, ch2BinWidth);
-			// set position of input/output cursor
-			histogram2DCursor.setPosition( pos );
-			// get current value at position and increment it
-			long count = histogram2DCursor.get().getIntegerLong();
-			count++;
 
-			histogram2DCursor.get().set(count);
+			if (pos[0] >= 0 && pos[1] >=0 && pos[0] < xBins && pos[1] < yBins) {
+				// set position of input/output cursor
+				histogram2DCursor.setPosition( pos );
+				// get current value at position and increment it
+				long count = histogram2DCursor.get().getIntegerLong();
+				count++;
+
+				histogram2DCursor.get().set(count);
+			} else {
+				ignoredPixelCount ++;
+			}
 		}
 
+		if (ignoredPixelCount > 0) {
+			addWarning("Ignored pixels while generating histogram.",
+					"" + ignoredPixelCount + " pixels were ignored while generating the 2D histogram \"" + title +
+							"\" because the grey values were out of range." +
+							"This may happen, if an image contains negative pixel values.");
+		}
 		xBinWidth = ch1BinWidth;
 		yBinWidth = ch2BinWidth;
 		xLabel = getLabelCh1();

--- a/src/main/java/algorithms/InputCheck.java
+++ b/src/main/java/algorithms/InputCheck.java
@@ -127,24 +127,24 @@ public class InputCheck<T extends RealType< T >> extends Algorithm<T> {
 
 		// add warnings if images contain negative values
 		if (ch1Min < 0 || ch2Min < 0) {
-			addWarning("negative minimum pixel value found",
-					"The minimum pixel value in at least one of the is channels is negative. Negative values might break the logic of some analysis methods. The reason is a basic assumption: The pixel value is assumed to be proportional to the photon count detected in a pixel. Negative photon counts make no physical sense.");
+			addWarning("Negative minimum pixel value found.",
+					"The minimum pixel value in at least one of the channels is negative. Negative values might break the logic of some analysis methods by breaking a basic basic assumption: The pixel value is assumed to be proportional to the number of photons detected in a pixel. Negative photon counts make no physical sense. Set negative pixel values to zero, or shift pixel intensities higher so there are no negative pixel values.");
 		}
 
 		// add warnings if values are not in tolerance range
 		if ( Math.abs(zeroZeroRatio) > maxZeroZeroRatio ) {
 
-			addWarning("zero-zero ratio too high",
+			addWarning("Zero-zero ratio too high",
 				"The ratio between zero-zero pixels and other pixels is large: "
 				+ IJ.d2s(zeroZeroRatio, 2) + ". Maybe you should use a ROI.");
 		}
 		if ( Math.abs(ch1SaturatedRatio) > maxSaturatedRatio ) {
-			addWarning("saturated ch1 ratio too high",
+			addWarning("Saturated ch1 ratio too high",
 				"The ratio between saturated pixels and other pixels in channel one is large: "
 				+ IJ.d2s(maxSaturatedRatio, 2) + ". Maybe you should use a ROI.");
 		}
 		if ( Math.abs(ch1SaturatedRatio) > maxSaturatedRatio ) {
-			addWarning("saturated ch2 ratio too high",
+			addWarning("Saturated ch2 ratio too high",
 				"The ratio between saturated pixels and other pixels in channel two is large: "
 				+ IJ.d2s(maxSaturatedRatio, 2) + ". Maybe you should use a ROI.");
 		}

--- a/src/main/java/algorithms/InputCheck.java
+++ b/src/main/java/algorithms/InputCheck.java
@@ -125,6 +125,12 @@ public class InputCheck<T extends RealType< T >> extends Algorithm<T> {
 		// get job name so the ResultsHandler implementation can have it.
 		colocJobName = container.getJobName();
 
+		// add warnings if images contain negative values
+		if (ch1Min < 0 || ch2Min < 0) {
+			addWarning("negative minimum grey value found",
+					"The minimum grey value in at least one of the is channels is negative. Negative values may cause faulty results in some analysis methods. The reason is a basic assumption: The pixels grey value is assumed to be proportional to the photon count in a certain area. Negative photon counts are not possible.");
+		}
+
 		// add warnings if values are not in tolerance range
 		if ( Math.abs(zeroZeroRatio) > maxZeroZeroRatio ) {
 

--- a/src/main/java/algorithms/InputCheck.java
+++ b/src/main/java/algorithms/InputCheck.java
@@ -127,25 +127,25 @@ public class InputCheck<T extends RealType< T >> extends Algorithm<T> {
 
 		// add warnings if images contain negative values
 		if (ch1Min < 0 || ch2Min < 0) {
-			addWarning("negative minimum grey value found",
-					"The minimum grey value in at least one of the is channels is negative. Negative values may cause faulty results in some analysis methods. The reason is a basic assumption: The pixels grey value is assumed to be proportional to the photon count in a certain area. Negative photon counts are not possible.");
+			addWarning("negative minimum pixel value found",
+					"The minimum pixel value in at least one of the is channels is negative. Negative values might break the logic of some analysis methods. The reason is a basic assumption: The pixel value is assumed to be proportional to the photon count detected in a pixel. Negative photon counts make no physical sense.");
 		}
 
 		// add warnings if values are not in tolerance range
 		if ( Math.abs(zeroZeroRatio) > maxZeroZeroRatio ) {
 
 			addWarning("zero-zero ratio too high",
-				"The ratio between zero-zero pixels and other pixels is larger "
+				"The ratio between zero-zero pixels and other pixels is large: "
 				+ IJ.d2s(zeroZeroRatio, 2) + ". Maybe you should use a ROI.");
 		}
 		if ( Math.abs(ch1SaturatedRatio) > maxSaturatedRatio ) {
 			addWarning("saturated ch1 ratio too high",
-				"The ratio between saturated pixels and other pixels in channel one is larger "
+				"The ratio between saturated pixels and other pixels in channel one is large: "
 				+ IJ.d2s(maxSaturatedRatio, 2) + ". Maybe you should use a ROI.");
 		}
 		if ( Math.abs(ch1SaturatedRatio) > maxSaturatedRatio ) {
 			addWarning("saturated ch2 ratio too high",
-				"The ratio between saturated pixels and other pixels in channel two is larger "
+				"The ratio between saturated pixels and other pixels in channel two is large: "
 				+ IJ.d2s(maxSaturatedRatio, 2) + ". Maybe you should use a ROI.");
 		}
 	}


### PR DESCRIPTION
I added two checks preventing a crash and warning the user when using images with negative pixel values to resolve #48 .
* The InputCheck now warns if negative minimum grey values are found.
* Furthermore, any attempts to access the 2D histogram out of range are prevented and counted. The user will then get a warning with information on how many pixels had to be ignored.

Cheers,
Robert